### PR TITLE
Change cardano-cli command/path

### DIFF
--- a/automint/automint/config.py
+++ b/automint/automint/config.py
@@ -1,4 +1,4 @@
 # This must be either (1) the full file path to the cardano-cli
 # executable or (2) a valid command in the shell (ie `cardano-cli` is
 # working for most people)
-CARDANO_CLI = '/Applications/Daedalus Mainnet.app/Contents/MacOS/cardano-cli'
+CARDANO_CLI = 'cardano-cli'


### PR DESCRIPTION
In `automint/config.py`, change the CLI command for `cardano-cli` from full file path to executable to just the CLI alias.